### PR TITLE
Add DeleteBirthdate mutation and more frontend stuff

### DIFF
--- a/app/graphql/mutations/delete_birthdate.rb
+++ b/app/graphql/mutations/delete_birthdate.rb
@@ -1,0 +1,23 @@
+module Types
+  class DeleteBirthdateInputType < Types::BaseInputObject
+    argument :person_id, ID, required: true
+  end
+end
+
+module Mutations
+  class DeleteBirthdate < BaseMutation
+    argument :input, Types::DeleteBirthdateInputType, required: true
+
+    type Boolean
+
+    def resolve(input:)
+      person = Person.find_by(id: input.person_id)
+
+      if person
+        person.update(birth_year: nil, birth_month: nil, birth_day: nil)
+        return true
+      end
+      false
+    end
+  end
+end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -82,6 +82,10 @@ type CreateUserPayload {
   user: User
 }
 
+input DeleteBirthdateInput {
+  personId: ID!
+}
+
 input DeleteNoteInput {
   noteId: ID!
 }
@@ -115,6 +119,7 @@ type Mutation {
   createParentChildRelationship(input: CreateParentChildRelationshipInput!): CreateParentChildRelationshipPayload!
   createPerson(input: CreatePersonInput!): CreatePersonPayload!
   createUser(input: CreateUserInput!): CreateUserPayload!
+  deleteBirthdate(input: DeleteBirthdateInput!): Boolean!
   deleteNote(input: DeleteNoteInput!): Boolean!
   deleteParentChildRelationship(input: DeleteParentChildRelationshipInput!): Boolean!
   login(input: LoginInput!): LoginPayload!

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -13,6 +13,7 @@ module Types
     field :create_age, mutation: Mutations::CreateAge
     field :update_age, mutation: Mutations::UpdateAge
     field :create_or_update_birthdate, mutation: Mutations::CreateOrUpdateBirthdate
+    field :delete_birthdate, mutation: Mutations::DeleteBirthdate
     field :create_parent_child_relationship, mutation: Mutations::CreateParentChildRelationship
     field :update_parent_child_relationship, mutation: Mutations::UpdateParentChildRelationship
     field :delete_parent_child_relationship, mutation: Mutations::DeleteParentChildRelationship

--- a/app/javascript/client/graphqlTypes.tsx
+++ b/app/javascript/client/graphqlTypes.tsx
@@ -89,6 +89,10 @@ export type CreateUserPayload = {
   user?: Maybe<User>;
 };
 
+export type DeleteBirthdateInput = {
+  personId: Scalars['ID'];
+};
+
 export type DeleteNoteInput = {
   noteId: Scalars['ID'];
 };
@@ -123,6 +127,7 @@ export type Mutation = {
   createParentChildRelationship: CreateParentChildRelationshipPayload;
   createPerson: CreatePersonPayload;
   createUser: CreateUserPayload;
+  deleteBirthdate: Scalars['Boolean'];
   deleteNote: Scalars['Boolean'];
   deleteParentChildRelationship: Scalars['Boolean'];
   login: LoginPayload;
@@ -160,6 +165,11 @@ export type MutationCreatePersonArgs = {
 
 export type MutationCreateUserArgs = {
   input: CreateUserInput;
+};
+
+
+export type MutationDeleteBirthdateArgs = {
+  input: DeleteBirthdateInput;
 };
 
 
@@ -439,6 +449,16 @@ export type CreateAgeMutation = (
       & Pick<Error, 'path' | 'message'>
     )>> }
   ) }
+);
+
+export type DeleteBirthdateMutationVariables = Exact<{
+  input: DeleteBirthdateInput;
+}>;
+
+
+export type DeleteBirthdateMutation = (
+  { __typename?: 'Mutation' }
+  & Pick<Mutation, 'deleteBirthdate'>
 );
 
 export type CreateOrUpdateBirthdateMutationVariables = Exact<{
@@ -896,6 +916,36 @@ export function useCreateAgeMutation(baseOptions?: Apollo.MutationHookOptions<Cr
 export type CreateAgeMutationHookResult = ReturnType<typeof useCreateAgeMutation>;
 export type CreateAgeMutationResult = Apollo.MutationResult<CreateAgeMutation>;
 export type CreateAgeMutationOptions = Apollo.BaseMutationOptions<CreateAgeMutation, CreateAgeMutationVariables>;
+export const DeleteBirthdateDocument = gql`
+    mutation DeleteBirthdate($input: DeleteBirthdateInput!) {
+  deleteBirthdate(input: $input)
+}
+    `;
+export type DeleteBirthdateMutationFn = Apollo.MutationFunction<DeleteBirthdateMutation, DeleteBirthdateMutationVariables>;
+
+/**
+ * __useDeleteBirthdateMutation__
+ *
+ * To run a mutation, you first call `useDeleteBirthdateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteBirthdateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteBirthdateMutation, { data, loading, error }] = useDeleteBirthdateMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDeleteBirthdateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteBirthdateMutation, DeleteBirthdateMutationVariables>) {
+        return Apollo.useMutation<DeleteBirthdateMutation, DeleteBirthdateMutationVariables>(DeleteBirthdateDocument, baseOptions);
+      }
+export type DeleteBirthdateMutationHookResult = ReturnType<typeof useDeleteBirthdateMutation>;
+export type DeleteBirthdateMutationResult = Apollo.MutationResult<DeleteBirthdateMutation>;
+export type DeleteBirthdateMutationOptions = Apollo.BaseMutationOptions<DeleteBirthdateMutation, DeleteBirthdateMutationVariables>;
 export const CreateOrUpdateBirthdateDocument = gql`
     mutation CreateOrUpdateBirthdate($input: CreateOrUpdateBirthdateInput!) {
   createOrUpdateBirthdate(input: $input) {

--- a/app/javascript/client/home/HomeContainer.tsx
+++ b/app/javascript/client/home/HomeContainer.tsx
@@ -52,7 +52,10 @@ const InternalHomeContainer: FC<HomeContainerProps> = () => {
 
   const [newPersonFieldVisible, toggleNewPersonFieldVisible] = useState(false);
   const [logoutMutation] = useLogoutMutation();
-  const { data: userData } = useGetUserForHomeContainerQuery();
+  const {
+    data: userData,
+    refetch: refetchUserData,
+  } = useGetUserForHomeContainerQuery();
 
   // To do (eventually): Use a loading spinner for loading state
   if (!userData) return null;
@@ -78,7 +81,9 @@ const InternalHomeContainer: FC<HomeContainerProps> = () => {
       <button onClick={() => toggleNewPersonFieldVisible(true)}>
         Add a new person profile
       </button>
-      {newPersonFieldVisible && <AddPersonForm />}
+      {newPersonFieldVisible && (
+        <AddPersonForm refetchUserData={refetchUserData} />
+      )}
       {profileLinks}
     </>
   );

--- a/app/javascript/client/profiles/AddPersonForm.spec.tsx
+++ b/app/javascript/client/profiles/AddPersonForm.spec.tsx
@@ -25,6 +25,8 @@ describe('<AddPersonForm />', () => {
   let history: History;
 
   beforeEach(() => {
+    const refetchUserData = jest.fn();
+
     mountComponent = async (mocks = [createPersonMutation()]) => {
       await act(async () => {
         component = mount(
@@ -34,7 +36,12 @@ describe('<AddPersonForm />', () => {
                 path="/home"
                 render={(routerProps) => {
                   history = routerProps.history;
-                  return <AddPersonForm {...routerProps} />;
+                  return (
+                    <AddPersonForm
+                      refetchUserData={refetchUserData}
+                      {...routerProps}
+                    />
+                  );
                 }}
               />
             </MemoryRouter>

--- a/app/javascript/client/profiles/AddPersonForm.spec.tsx
+++ b/app/javascript/client/profiles/AddPersonForm.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  AddPersonForm,
+  AddPersonFormData,
+  AddPersonFormProps,
+} from './AddPersonForm';
+import { FormUtils, formUtils } from 'client/test/utils/formik';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import {
+  createPersonMutation,
+  createPersonResult,
+} from 'client/test/mutations/addPerson';
+import { ReactWrapper, mount } from 'enzyme';
+import { Form } from 'formik';
+import { History } from 'history';
+import { RouteComponentProps } from 'react-router-dom';
+import { act } from 'react-dom/test-utils';
+import wait from 'waait';
+
+describe('<AddPersonForm />', () => {
+  let mountComponent: (mocks?: MockedResponse[]) => Promise<void>;
+  let component: ReactWrapper<AddPersonFormProps & RouteComponentProps>;
+  let form: FormUtils;
+  let history: History;
+
+  beforeEach(() => {
+    mountComponent = async (mocks = [createPersonMutation()]) => {
+      await act(async () => {
+        component = mount(
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <MemoryRouter initialEntries={[{ pathname: '/home' }]}>
+              <Route
+                path="/home"
+                render={(routerProps) => {
+                  history = routerProps.history;
+                  return <AddPersonForm {...routerProps} />;
+                }}
+              />
+            </MemoryRouter>
+          </MockedProvider>,
+        );
+        await wait(0);
+        component.update();
+      });
+    };
+  });
+
+  it('exists', async () => {
+    await mountComponent();
+    expect(component.exists()).toBe(true);
+  });
+
+  it('has two form fields', async () => {
+    await mountComponent();
+    form = formUtils<AddPersonFormData>(component.find(Form));
+
+    expect(component.find(Form).exists()).toBe(true);
+    expect(form.findInputByName('firstName').exists()).toBe(true);
+    expect(form.findInputByName('lastName').exists()).toBe(true);
+  });
+
+  describe('form validations', () => {
+    it('requires a first name', async () => {
+      await mountComponent();
+      form = formUtils<AddPersonFormData>(component.find(Form));
+
+      await form.submit();
+      expect(
+        component
+          .text()
+          .includes(
+            'Please provide at least a first name when adding a new person',
+          ),
+      ).toBe(true);
+      await form.fill({ firstName: 'Roger', lastName: 'Mexico' });
+      await form.submit();
+      expect(
+        component
+          .text()
+          .includes(
+            'Please provide at least a first name when adding a new person',
+          ),
+      ).toBe(false);
+    });
+  });
+
+  describe('submitting the form', () => {
+    it('uses a mutation to create a new person if there are no server-side errors', async () => {
+      const createPerson = createPersonMutation();
+
+      await mountComponent([createPerson]);
+      form = formUtils<AddPersonFormData>(component.find(Form));
+
+      await form.fill({ firstName: 'Roger', lastName: 'Mexico' });
+      await form.submit();
+      expect(createPerson.newData).toHaveBeenCalled();
+    });
+
+    it('redirects to the new person page if the form submission is successful', async () => {
+      await mountComponent();
+      form = formUtils<AddPersonFormData>(component.find(Form));
+      await form.fill({ firstName: 'Roger', lastName: 'Mexico' });
+      await form.submit();
+
+      await act(async () => await wait(0));
+      expect(history.location.pathname).toEqual(
+        `/profiles/${createPersonResult.person?.id}`,
+      );
+    });
+  });
+});

--- a/app/javascript/client/profiles/AddPersonForm.tsx
+++ b/app/javascript/client/profiles/AddPersonForm.tsx
@@ -13,14 +13,17 @@ const ValidationSchema = yup.object().shape({
   lastName: yup.string(),
 });
 
-export interface AddPersonFormProps {}
+export interface AddPersonFormProps extends RouteComponentProps {
+  refetchUserData?: () => void;
+}
 
 export interface AddPersonFormData {
   firstName: string;
   lastName?: string;
 }
 
-const InternalAddPersonForm: FC<AddPersonFormProps & RouteComponentProps> = ({
+const InternalAddPersonForm: FC<AddPersonFormProps> = ({
+  refetchUserData,
   history,
 }) => {
   const [createPersonMutation] = useCreatePersonMutation();
@@ -45,6 +48,7 @@ const InternalAddPersonForm: FC<AddPersonFormProps & RouteComponentProps> = ({
       handleFormErrors<AddPersonFormData>(errors, setErrors, setStatus);
     } else {
       const personId = response.data?.createPerson.person?.id;
+      refetchUserData && refetchUserData();
       history.push(`/profiles/${personId}`);
     }
   };
@@ -83,4 +87,7 @@ const InternalAddPersonForm: FC<AddPersonFormProps & RouteComponentProps> = ({
   );
 };
 
-export const AddPersonForm = withRouter(InternalAddPersonForm);
+export const AddPersonForm = withRouter(
+  InternalAddPersonForm,
+) as React.ComponentType<any>;
+// The type-casting hack above solves a TypeScript error from extending RouteComponentProps

--- a/app/javascript/client/profiles/AddPersonForm.tsx
+++ b/app/javascript/client/profiles/AddPersonForm.tsx
@@ -7,13 +7,15 @@ import * as yup from 'yup';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 const ValidationSchema = yup.object().shape({
-  firstName: yup.string().required(),
+  firstName: yup
+    .string()
+    .required('Please provide at least a first name when adding a new person'),
   lastName: yup.string(),
 });
 
-interface AddPersonFormProps {}
+export interface AddPersonFormProps {}
 
-interface AddPersonFormData {
+export interface AddPersonFormData {
   firstName: string;
   lastName?: string;
 }

--- a/app/javascript/client/profiles/birthdate/BirthdateContainer.tsx
+++ b/app/javascript/client/profiles/birthdate/BirthdateContainer.tsx
@@ -1,6 +1,14 @@
 import React, { FC, useState } from 'react';
+import { useDeleteBirthdateMutation } from 'client/graphqlTypes';
 import { BirthdateForm } from './BirthdateForm';
 import { MONTHS } from './utils';
+import { gql } from '@apollo/client';
+
+gql`
+  mutation DeleteBirthdate($input: DeleteBirthdateInput!) {
+    deleteBirthdate(input: $input)
+  }
+`;
 
 interface BirthdateContainerProps {
   birthYear?: number | null;
@@ -10,10 +18,21 @@ interface BirthdateContainerProps {
 }
 
 export const BirthdateContainer: FC<BirthdateContainerProps> = (props) => {
+  const [deleteBirthdateMutation] = useDeleteBirthdateMutation();
   const { birthYear, birthMonth, birthDay, personId } = props;
   const [editFlag, setEditFlag] = useState(false);
+  const [deletedFlag, setDeletedFlag] = useState(false);
 
-  const editButton = <button onClick={() => setEditFlag(true)}>Edit</button>;
+  const deleteBirthdate = async () => {
+    await deleteBirthdateMutation({
+      variables: {
+        input: {
+          personId,
+        },
+      },
+    });
+    setDeletedFlag(true);
+  };
 
   const birthdateContainerContent = (
     year: number | null | undefined,
@@ -67,7 +86,8 @@ export const BirthdateContainer: FC<BirthdateContainerProps> = (props) => {
   ) : (
     <>
       {birthdateContainerContent(birthYear, month, day)}
-      {editButton}
+      <button onClick={() => setEditFlag(true)}>Edit</button>
+      <button onClick={() => deleteBirthdate()}>Delete</button>
     </>
   );
 };

--- a/app/javascript/client/profiles/birthdate/BirthdateContainer.tsx
+++ b/app/javascript/client/profiles/birthdate/BirthdateContainer.tsx
@@ -39,6 +39,8 @@ export const BirthdateContainer: FC<BirthdateContainerProps> = (props) => {
     month: string,
     day: string,
   ) => {
+    if (deletedFlag) return <></>;
+
     if (year && month && !day) {
       return (
         <div>

--- a/app/javascript/client/test/mutations/addPerson.ts
+++ b/app/javascript/client/test/mutations/addPerson.ts
@@ -1,0 +1,35 @@
+import {
+  CreatePersonMutation,
+  CreatePersonDocument,
+  CreatePersonInput,
+} from 'client/graphqlTypes';
+import { MockedResponse } from '@apollo/client/testing';
+
+export const createPersonInput: CreatePersonInput = {
+  firstName: 'Roger',
+  lastName: 'Mexico',
+};
+
+export const createPersonResult: CreatePersonMutation['createPerson'] = {
+  errors: null,
+  person: {
+    id: 'some-uuid',
+    ...createPersonInput,
+  },
+};
+
+export const createPersonMutation = ({
+  input = createPersonInput,
+  result = createPersonResult,
+} = {}): MockedResponse => ({
+  request: {
+    query: CreatePersonDocument,
+    variables: {
+      input,
+    },
+  },
+  result: { data: { createPerson: result } },
+  newData: jest.fn(() => ({
+    data: { createPerson: result },
+  })),
+});

--- a/app/javascript/client/test/utils/formik.ts
+++ b/app/javascript/client/test/utils/formik.ts
@@ -18,6 +18,7 @@ export const formUtils = <FormType extends { [key: string]: any }>(
       Component.simulate('submit');
       await act(async () => await wait(0));
     },
+    findInputByName: (name: string) => Component.find(`input[name="${name}"]`),
   };
 };
 

--- a/spec/birthdate/requests/delete_birthdate_spec.rb
+++ b/spec/birthdate/requests/delete_birthdate_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'delete_birthdate mutation', type: :request do
+  let(:endpoint) { '/graphql' }
+  let(:person_with_birthdate) { create(:person, :with_full_birthdate) }
+  let(:query_string) do
+    "
+        mutation DeleteBirthdate($input: DeleteBirthdateInput!) {
+            deleteBirthdate(input: $input)
+        }
+    "
+  end
+
+  it 'deletes the birthdate from a person and returns true if the person no longer has a birthdate associated with them' do
+    variables =
+      {
+          input: {
+              personId: person_with_birthdate.id,
+          }
+      }
+
+    post(
+      endpoint,
+      params: { query: query_string, variables: variables.to_json }
+    )
+
+    person_with_birthdate.reload
+
+    mutation_response = JSON.parse(response.body).dig('data', 'deleteBirthdate')
+    expect(mutation_response).to be true
+    expect(person_with_birthdate.birth_year).to be_nil
+    expect(person_with_birthdate.birth_month).to be_nil
+    expect(person_with_birthdate.birth_day).to be_nil
+  end
+
+  it 'does nothing and returns false if the person_id does not exist' do
+    variables =
+      {
+          input: {
+              personId: 'non-existent-person-id',
+          }
+      }
+
+    post(
+      endpoint,
+      params: { query: query_string, variables: variables }
+    )
+
+    mutation_response = JSON.parse(response.body).dig('data', 'deleteBirthdate')
+    expect(mutation_response).to be false
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
         trait :with_full_birthdate do
             birth_year { 1937 }
-            birth_month { 'May' }
+            birth_month { 5 }
             birth_day { 8 }
         end
     end

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
         "baseUrl": "app/javascript/",
         "strict": true,
         "esModuleInterop": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "typeRoots": [
+            "node_modules/@types"
+        ],
     },
     "exclude": [
         "**/*.spec.ts",


### PR DESCRIPTION
* Adds `DeleteBirthdate` mutation and spec
* Adds a delete button to the `BirthdateContainer`
* Adds `refetchUserData` to the `AddPersonForm` in order to force a refresh of the user's people profiles on their home page after they create a new person (so that the person shows up on their home page when navigating back there without needing to refresh the page)
* Adds a Jest spec file for the `AddPersonForm`
