### PR TITLE
Add parent child form spec

### DIFF
--- a/app/graphql/mutations/create_parent_child_relationship.rb
+++ b/app/graphql/mutations/create_parent_child_relationship.rb
@@ -14,6 +14,12 @@ module Mutations
     field :parent_child_relationship, Types::ParentChildType, null: true
 
     def resolve(input:)
+      if !input.parent_id
+        return { errors: [{ path: '', message: 'Please create or choose a parent to add!' }] }
+      elsif !input.child_id
+        return { errors: [{ path: '', message: 'Please create or choose a child to add!' }] }
+      end
+
       parent_child = ParentChild.new(
         **input
       )

--- a/app/javascript/client/profiles/parent_child/ParentChildForm.spec.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentChildForm.spec.tsx
@@ -12,13 +12,17 @@ import {
   createParentChildRelationshipMutation,
   createParentChildRelationshipResult,
 } from 'client/test/mutations/createParentChild';
+import { getUserForHomeContainerQuery } from 'client/test/queries/getUserForHomeContainer';
 import { ReactWrapper, mount } from 'enzyme';
 import { Form } from 'formik';
 import { act } from 'react-dom/test-utils';
 import wait from 'waait';
 
 describe('<ParentChildForm />', () => {
-  let mountComponent: (mocks?: MockedResponse[]) => Promise<void>;
+  let mountComponent: (
+    mocks?: MockedResponse[],
+    props?: ParentChildFormProps,
+  ) => Promise<void>;
   let component: ReactWrapper<ParentChildFormProps>;
   let createParentChildProps: ParentChildFormProps;
   let form: FormUtils;
@@ -32,7 +36,10 @@ describe('<ParentChildForm />', () => {
     };
 
     mountComponent = async (
-      mocks = [createParentChildRelationshipMutation()],
+      mocks = [
+        createParentChildRelationshipMutation(),
+        getUserForHomeContainerQuery(),
+      ],
       props = createParentChildProps,
     ) => {
       await act(async () => {
@@ -58,5 +65,53 @@ describe('<ParentChildForm />', () => {
   it('exists', async () => {
     await mountComponent();
     expect(component.exists()).toBe(true);
+  });
+
+  it('has eight form fields when the parent or child to be added is a new_contact', async () => {
+    await mountComponent();
+    form = formUtils<ParentChildFormData>(component.find(Form));
+
+    expect(component.find(Form).exists()).toBe(true);
+
+    expect(form.findInputByName('newOrCurrentContact').exists()).toBe(true);
+    expect(form.findInputByName('showOnDashboard').exists()).toBe(true);
+    expect(form.findInputByName('firstName').exists()).toBe(true);
+    expect(form.findInputByName('lastName').exists()).toBe(true);
+    expect(form.findInputByName('age').exists()).toBe(true);
+    expect(form.findInputByName('monthsOld').exists()).toBe(true);
+    expect(form.findSelectByName('parentType').exists()).toBe(true);
+    expect(form.findTextareaByName('note').exists()).toBe(true);
+  });
+
+  it('has four form fields when the parent or child to be added is a current_contact', async () => {
+    const props = {
+      initialValues: {
+        ...blankInitialValues,
+        newOrCurrentContact: 'current_person',
+      },
+      personFirstName: 'Ada',
+      setFieldToAdd: jest.fn(),
+      childId: 'ada-lovelace-uuid',
+    };
+
+    await mountComponent(
+      [createParentChildRelationshipMutation(), getUserForHomeContainerQuery()],
+      props,
+    );
+    form = formUtils<ParentChildFormData>(component.find(Form));
+
+    expect(form.findInputByName('newOrCurrentContact').exists()).toBe(true);
+    expect(form.findSelectByName('formParentId').exists()).toBe(true);
+    expect(form.findSelectByName('parentType').exists()).toBe(true);
+    expect(form.findTextareaByName('note').exists()).toBe(true);
+  });
+
+  describe('form validations', () => {
+    describe('when the parent or child being added is a new_contact', () => {
+      it('requires a first name for the new contact', async () => {});
+    });
+    describe('when the parent or child being added is a current_contact', () => {
+      it('returns a server-side error if the parent or child is not selected', async () => {});
+    });
   });
 });

--- a/app/javascript/client/profiles/parent_child/ParentChildForm.spec.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentChildForm.spec.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import {
+  ParentChildForm,
+  ParentChildFormData,
+  ParentChildFormProps,
+} from './ParentChildForm';
+import { FormUtils, formUtils } from 'client/test/utils/formik';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';

--- a/app/javascript/client/profiles/parent_child/ParentChildForm.spec.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentChildForm.spec.tsx
@@ -3,7 +3,60 @@ import {
   ParentChildForm,
   ParentChildFormData,
   ParentChildFormProps,
+  blankInitialValues,
 } from './ParentChildForm';
 import { FormUtils, formUtils } from 'client/test/utils/formik';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import {
+  createParentChildRelationshipMutation,
+  createParentChildRelationshipResult,
+} from 'client/test/mutations/createParentChild';
+import { ReactWrapper, mount } from 'enzyme';
+import { Form } from 'formik';
+import { act } from 'react-dom/test-utils';
+import wait from 'waait';
+
+describe('<ParentChildForm />', () => {
+  let mountComponent: (mocks?: MockedResponse[]) => Promise<void>;
+  let component: ReactWrapper<ParentChildFormProps>;
+  let createParentChildProps: ParentChildFormProps;
+  let form: FormUtils;
+
+  beforeEach(() => {
+    createParentChildProps = {
+      initialValues: blankInitialValues,
+      personFirstName: 'Ada',
+      setFieldToAdd: jest.fn(),
+      childId: 'ada-lovelace-uuid',
+    };
+
+    mountComponent = async (
+      mocks = [createParentChildRelationshipMutation()],
+      props = createParentChildProps,
+    ) => {
+      await act(async () => {
+        component = mount(
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <MemoryRouter
+              initialEntries={[{ pathname: '/profiles/ada-lovelace-uuid' }]}
+            >
+              <Route
+                path="/profiles/ada-lovelace-uuid"
+                render={() => <ParentChildForm {...props} />}
+              />
+              ;
+            </MemoryRouter>
+          </MockedProvider>,
+        );
+        await wait(0);
+        component.update();
+      });
+    };
+  });
+
+  it('exists', async () => {
+    await mountComponent();
+    expect(component.exists()).toBe(true);
+  });
+});

--- a/app/javascript/client/profiles/parent_child/ParentChildForm.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentChildForm.tsx
@@ -104,7 +104,7 @@ export interface ParentChildFormProps {
   setEditFlag?: (bool: boolean) => void;
 }
 
-const blankInitialValues = {
+export const blankInitialValues = {
   firstName: '',
   lastName: '',
   formParentId: '',

--- a/app/javascript/client/profiles/parent_child/ParentChildForm.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentChildForm.tsx
@@ -82,7 +82,7 @@ const ParentChildFormValidationSchema = yup.object().shape({
   note: yup.string(),
 });
 
-interface ParentChildFormData {
+export interface ParentChildFormData {
   firstName?: string;
   lastName?: string;
   formParentId: string;
@@ -95,7 +95,7 @@ interface ParentChildFormData {
   note?: string | null | undefined;
 }
 
-interface ParentChildFormProps {
+export interface ParentChildFormProps {
   setFieldToAdd?: (field: string) => void;
   personFirstName: string;
   parentId?: string;

--- a/app/javascript/client/test/mutations/createAge.ts
+++ b/app/javascript/client/test/mutations/createAge.ts
@@ -1,0 +1,35 @@
+import {
+  CreateAgeMutation,
+  CreateAgeDocument,
+  CreateAgeInput,
+} from 'client/graphqlTypes';
+import { MockedResponse } from '@apollo/client/testing';
+
+export const createAgeInput: CreateAgeInput = {
+  personId: 'lord-byron-uuid',
+  age: 28,
+};
+
+export const createAgeResult: CreateAgeMutation['createAge'] = {
+  errors: null,
+  person: {
+    id: 'lord-byron-uuid',
+    age: 28,
+  },
+};
+
+export const createAgeMutation = ({
+  input = createAgeInput,
+  result = createAgeResult,
+} = {}): MockedResponse => ({
+  request: {
+    query: CreateAgeDocument,
+    variables: {
+      input,
+    },
+  },
+  result: { data: { createAge: result } },
+  newData: jest.fn(() => ({
+    data: { createAge: result },
+  })),
+});

--- a/app/javascript/client/test/mutations/createParentChild.ts
+++ b/app/javascript/client/test/mutations/createParentChild.ts
@@ -1,0 +1,46 @@
+import {
+  CreateParentChildRelationshipMutation,
+  CreateParentChildRelationshipDocument,
+  CreateParentChildRelationshipInput,
+} from 'client/graphqlTypes';
+import { MockedResponse } from '@apollo/client/testing';
+
+export const createParentChildRelationshipInput: CreateParentChildRelationshipInput = {
+  parentId: 'some-person-id',
+  childId: 'another-person-id',
+  parentType: 'biological',
+};
+
+export const createParentChildRelationshipResult: CreateParentChildRelationshipMutation['createParentChildRelationship'] = {
+  errors: null,
+  parentChildRelationship: {
+    id: 'some-uuid',
+    parent: {
+      id: 'some-person-id',
+      firstName: 'Lord',
+      lastName: 'Byron',
+    },
+    child: {
+      id: 'another-person-id',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    },
+    parentType: 'biological',
+  },
+};
+
+export const createParentChildRelationshipMutation = ({
+  input = createParentChildRelationshipInput,
+  result = createParentChildRelationshipResult,
+} = {}): MockedResponse => ({
+  request: {
+    query: CreateParentChildRelationshipDocument,
+    variables: {
+      input,
+    },
+  },
+  result: { data: { createParentChildRelationship: result } },
+  newData: jest.fn(() => ({
+    data: { createParentChildRelationship: result },
+  })),
+});

--- a/app/javascript/client/test/mutations/createParentChild.ts
+++ b/app/javascript/client/test/mutations/createParentChild.ts
@@ -6,22 +6,22 @@ import {
 import { MockedResponse } from '@apollo/client/testing';
 
 export const createParentChildRelationshipInput: CreateParentChildRelationshipInput = {
-  parentId: 'some-person-id',
-  childId: 'another-person-id',
+  parentId: 'lord-byron-uuid',
+  childId: 'ada-lovelace-uuid',
   parentType: 'biological',
 };
 
 export const createParentChildRelationshipResult: CreateParentChildRelationshipMutation['createParentChildRelationship'] = {
   errors: null,
   parentChildRelationship: {
-    id: 'some-uuid',
+    id: 'byron-lovelace-uuid',
     parent: {
-      id: 'some-person-id',
+      id: 'lord-byron-uuid',
       firstName: 'Lord',
       lastName: 'Byron',
     },
     child: {
-      id: 'another-person-id',
+      id: 'ada-lovelace-uuid',
       firstName: 'Ada',
       lastName: 'Lovelace',
     },

--- a/app/javascript/client/test/queries/getUserForHomeContainer.ts
+++ b/app/javascript/client/test/queries/getUserForHomeContainer.ts
@@ -1,0 +1,30 @@
+import {
+  GetUserForHomeContainerDocument,
+  GetUserForHomeContainerQuery,
+} from 'client/graphqlTypes';
+import { MockedResponse } from '@apollo/client/testing';
+
+export const getUserForHomeContainerData: GetUserForHomeContainerQuery = {
+  user: {
+    id: 'ada-lovelace-uuid',
+    people: [
+      {
+        id: 'lady-byron-uuid',
+        firstName: 'Lady',
+        lastName: 'Byron',
+        showOnDashboard: true,
+      },
+    ],
+  },
+};
+
+export const getUserForHomeContainerQuery = (
+  data = getUserForHomeContainerData,
+): MockedResponse => ({
+  request: {
+    query: GetUserForHomeContainerDocument,
+  },
+  result: {
+    data,
+  },
+});

--- a/app/javascript/client/test/utils/formik.ts
+++ b/app/javascript/client/test/utils/formik.ts
@@ -14,11 +14,21 @@ export const formUtils = <FormType extends { [key: string]: any }>(
       });
       await act(async () => await wait(0));
     },
+    // check: async (values: string[]) => {
+    //   values.forEach((value) => {
+    //     Component.find(`input[value="${value}"]`).simulate('click');
+    //   });
+    //   await act(async () => await wait(0));
+    // },
     submit: async () => {
       Component.simulate('submit');
       await act(async () => await wait(0));
     },
     findInputByName: (name: string) => Component.find(`input[name="${name}"]`),
+    findSelectByName: (name: string) =>
+      Component.find(`select[name="${name}"]`),
+    findTextareaByName: (name: string) =>
+      Component.find(`textarea[name="${name}"]`),
   };
 };
 


### PR DESCRIPTION
* Adds a partially complete spec file for `ParentChildForm` (took a while to figure out how to change a checkbox or radio button in Formik — turns out there doesn't seem to be a simple way! At least not that I could find. So my solution for now will be to change `initialValues` in the props to test different paths with those types of inputs.)
* Adds `createAge`, `createParentChild`, and `getUserForHomeContainer` mocks