### PR TITLE
Add batch loaders

### DIFF
--- a/app/graphql/association_loader.rb
+++ b/app/graphql/association_loader.rb
@@ -1,0 +1,47 @@
+class AssociationLoader < GraphQL::Batch::Loader
+  def self.validate(model, association_name)
+    new(model, association_name)
+    nil
+  end
+
+  def initialize(model, association_name)
+    @model = model
+    @association_name = association_name
+    validate
+  end
+
+  def load(record)
+    raise TypeError, "#{@model} loader can't load association for #{record.class}" unless record.is_a?(@model)
+    return Promise.resolve(read_association(record)) if association_loaded(record)
+    super
+  end
+
+  def cache_key(record)
+    record.object_id
+  end
+
+  def perform(records)
+    preload_association(records)
+    records.each { |record| fulfill(record, read_association(record)) }
+  end
+
+  private
+
+  def validate
+    unless @model.reflect_on_association(@association_name)
+      raise ArgumentError, "No association #{association_name} on #{@model}"
+    end
+  end
+
+  def preload_association(records)
+    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name)
+  end
+
+  def read_association(record)
+    record.public_send(@association_name)
+  end
+
+  def association_loaded?(record)
+    record.association(@association_name).loaded?
+  end
+end

--- a/app/graphql/association_loader.rb
+++ b/app/graphql/association_loader.rb
@@ -12,7 +12,7 @@ class AssociationLoader < GraphQL::Batch::Loader
 
   def load(record)
     raise TypeError, "#{@model} loader can't load association for #{record.class}" unless record.is_a?(@model)
-    return Promise.resolve(read_association(record)) if association_loaded(record)
+    return Promise.resolve(read_association(record)) if association_loaded?(record)
     super
   end
 

--- a/app/graphql/fambly_schema.rb
+++ b/app/graphql/fambly_schema.rb
@@ -8,4 +8,7 @@ class FamblySchema < GraphQL::Schema
 
   # Add built-in connections for pagination
   use GraphQL::Pagination::Connections
+
+  # Shopify plugin for making batch queries
+  use GraphQL::Batch
 end

--- a/app/graphql/record_loader.rb
+++ b/app/graphql/record_loader.rb
@@ -1,0 +1,24 @@
+class RecordLoader < GraphQL::Batch::Loader
+  def initialize(model, column: model.primary_key, where: nil)
+    @model = model
+    @column = column.to_s
+    @column_type = model.type_for_attribute(@column)
+    @where = where
+  end
+
+  def load(key)
+    super(@column_type.cast(key))
+  end
+
+  def perform(keys)
+    query(keys).each { |record| fulfill(record.public_send(@column), record) }
+  end
+
+  private
+
+  def query(keys)
+    scope = @model
+    scope = scope.where(@where) if @where
+    scope.where(@column => keys)
+  end
+end

--- a/app/graphql/types/person_place_type.rb
+++ b/app/graphql/types/person_place_type.rb
@@ -11,4 +11,16 @@ module Types
     field :end_year, Int, null: true
     field :notes, [Types::NoteType], null: true
   end
+
+  def place
+    RecordLoader.for(Place).load(object.place_id)
+  end
+  
+  def person
+    RecordLoader.for(Person).load(object.person_id)
+  end
+
+  def notes
+    AssociationLoader.for(PersonPlace, :notes).load(object)
+  end
 end

--- a/app/graphql/types/person_type.rb
+++ b/app/graphql/types/person_type.rb
@@ -24,5 +24,37 @@ module Types
 
       object.months_old_from_full_birthdate || object.approximate_months_old_from_months_old
     end
+
+    def parents
+      child_parent_relationships.then do |child_parent_relationship_list|
+        parent_ids = child_parent_relationship_list.map(&:parent_id)
+        RecordLoader.for(Person).load_many(parent_ids)
+      end
+    end
+
+    def children
+      parent_child_relationships.then do |parent_child_relationship_list|
+        children_ids = parent_child_relationship_list.map(&:child_id)
+        RecordLoader.for(Person).load_many(children_ids)
+      end
+    end
+
+    def notes
+      AssociationLoader.for(Person, :notes).load(object)
+    end
+
+    def person_places
+      AssociationLoader.for(Person, :person_places).load(object)
+    end
+
+    private
+
+    def parent_child_relationships
+      AssociationLoader.for(Person, :parent_child_relationships).load(object)
+    end
+
+    def child_parent_relationships
+      AssociationLoader.for(Person, :child_parent_relationships).load(object)
+    end
   end
 end


### PR DESCRIPTION
* Adds `RecordLoader` and `AssociationLoader` classes for batch-loading records based on ActiveRecord associations (in order to avoid N+1 queries), using the `graphql-batch` gem
* Adds relevant queries where necessary in GraphQL types