### PR TITLE
Create dummy_emails

### DIFF
--- a/app/graphql/mutations/create_dummy_user.rb
+++ b/app/graphql/mutations/create_dummy_user.rb
@@ -1,0 +1,19 @@
+module Mutations
+  class CreateDummyUser < BaseMutation
+
+    field :dummy_email, Types::DummyEmailType, null: true
+
+    def resolve
+      email = SecureRandom.uuid + "@fakeemail.com"
+      user = User.new(email: email, password: "dummy_user_password")
+
+      if user.save
+        login_user(user)
+        dummy_email = DummyEmail.create(email: email, user_id: user.id)
+        return { dummy_email: dummy_email }
+      end
+
+      { errors: [{ path: '', message: 'Oops! Something went wrong. Please refresh the page and try again.' }] }
+    end
+  end
+end

--- a/app/graphql/types/dummy_email_type.rb
+++ b/app/graphql/types/dummy_email_type.rb
@@ -1,0 +1,7 @@
+module Types
+  class DummyEmailType < Types::BaseObject
+    field :id, ID, null: false
+    field :email, String, null: false
+    field :user, Types::UserType, null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,6 +5,9 @@ module Types
     field :login, mutation: Mutations::Login
     field :logout, mutation: Mutations::Logout
 
+    # Dummy users
+    field :create_dummy_user, mutation: Mutations::CreateDummyUser
+
     # Person + person fields
     field :create_person, mutation: Mutations::CreatePerson
     field :create_person_note, mutation: Mutations::CreatePersonNote

--- a/app/models/dummy_email.rb
+++ b/app/models/dummy_email.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: dummy_emails
+#
+#  id         :uuid             not null, primary key
+#  email      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :uuid
+#
+# Indexes
+#
+#  index_dummy_emails_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class DummyEmail < ApplicationRecord
+  validates :email, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
 
     has_many :people, dependent: :destroy
     has_many :tags
+    has_one :dummy_email
 
     def self.find_by_credentials(email, password)
         user = User.find_by(email: email)

--- a/db/migrate/20201006192723_create_dummy_emails.rb
+++ b/db/migrate/20201006192723_create_dummy_emails.rb
@@ -1,0 +1,9 @@
+class CreateDummyEmails < ActiveRecord::Migration[6.0]
+  def change
+    create_table :dummy_emails, id: :uuid do |t|
+      t.string :email, null: false
+      t.references :user, type: :uuid, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_21_201728) do
+ActiveRecord::Schema.define(version: 2020_10_06_192723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "dummy_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "email", null: false
+    t.uuid "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_dummy_emails_on_user_id"
+  end
 
   create_table "notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "content", null: false
@@ -115,6 +123,7 @@ ActiveRecord::Schema.define(version: 2020_09_21_201728) do
     t.index ["session_token"], name: "index_users_on_session_token", unique: true
   end
 
+  add_foreign_key "dummy_emails", "users"
   add_foreign_key "parent_children", "people", column: "child_id"
   add_foreign_key "parent_children", "people", column: "parent_id"
   add_foreign_key "people", "users"

--- a/spec/dummy_email/dummy_email_spec.rb
+++ b/spec/dummy_email/dummy_email_spec.rb
@@ -19,5 +19,13 @@
 require 'rails_helper'
 
 RSpec.describe DummyEmail, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:email) { 'some-uuid@fakeemail.com' }
+
+  describe 'ActiveModel validations' do
+    it 'is valid with valid attributes' do
+      expect(DummyEmail.create(email: email, user_id: user.id)).to be_valid
+    end
+  end
+
 end

--- a/spec/dummy_email/requests/create_dummy_user_spec.rb
+++ b/spec/dummy_email/requests/create_dummy_user_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'create_dummy_user mutation', type: :request do
+  let(:endpoint) { '/graphql' }
+  let(:user) { create(:user) }
+  let(:query_string) do
+    "
+        mutation CreateDummyUser {
+            createDummyUser {
+                dummyEmail {
+                    id
+                    email
+                    user {
+                      id
+                      email
+                    }
+                }
+                errors {
+                    path
+                    message
+                }
+            }
+        }
+    "
+  end
+
+  it 'creates a fake email address, creates a dummy user associated with that email address, and creates a DummyEmail with the fake email address and dummy user' do
+    post(
+      endpoint,
+      params: { query: query_string }
+    )
+
+    dummy_email = JSON.parse(response.body).dig('data', 'createDummyUser', 'dummyEmail')
+    expect(dummy_email['user']['email']).to eq(dummy_email['email'])
+    expect(DummyEmail.find(dummy_email['id'])).not_to be_nil
+  end
+end

--- a/spec/models/dummy_email_spec.rb
+++ b/spec/models/dummy_email_spec.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: dummy_emails
+#
+#  id         :uuid             not null, primary key
+#  email      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :uuid
+#
+# Indexes
+#
+#  index_dummy_emails_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe DummyEmail, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
* Adds a `dummy_emails` table to track dummy users — part of a setup to allow users to try the app without immediately having to sign up
* Adds a `CreateDummyUser` mutation with spec