### PR TITLE
Fix bugs

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -324,6 +324,7 @@ type Place {
 
 type Query {
   parentChildRelationshipByParentIdAndChildId(input: ParentChildInput!): ParentChild
+  people: [Person!]
   personById(personId: String!): Person
   siblingRelationshipBySiblingIds(input: SiblingRelationshipInput!): SiblingRelationship
   user: User

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,6 +1,7 @@
 module Types
   class QueryType < Types::BaseObject
     field :user, Types::UserType, null: true
+    field :people, [Types::PersonType], null: true
     field :person_by_id, Types::PersonType, null: true do
       argument :person_id, String, required: true
     end
@@ -28,6 +29,10 @@ module Types
 
     def user
       current_user
+    end
+
+    def people
+      current_user.people
     end
 
     def person_by_id(args)

--- a/app/javascript/client/common/Button.tsx
+++ b/app/javascript/client/common/Button.tsx
@@ -13,6 +13,7 @@ export const Button = styled.button`
   padding: 0.5rem 1.5rem;
   margin-right: ${({ marginRight }: ButtonProps) =>
     marginRight ? marginRight : '0'};
+  text-align: center;
 
   &:active {
     background: ${colors.orange};

--- a/app/javascript/client/form/FormikAutosuggest.tsx
+++ b/app/javascript/client/form/FormikAutosuggest.tsx
@@ -1,4 +1,4 @@
-import React, { FC, FormEvent, ReactNode } from 'react';
+import React, { FormEvent, ReactNode } from 'react';
 import Autosuggest, {
   SuggestionsFetchRequestedParams,
   SuggestionSelectedEventData,
@@ -8,7 +8,7 @@ import { escapeRegexCharacters } from 'client/profiles/utils';
 interface FormikAutosuggestProps<SuggestionType> {
   records: SuggestionType[];
   suggestions: SuggestionType[];
-  setSuggestions: (suggestions: any[]) => void;
+  setSuggestions: (suggestions: SuggestionType[]) => void;
   getSuggestionValue: (suggestion: SuggestionType) => string;
   inputValue: string;
   onSuggestionSelected: (
@@ -19,9 +19,7 @@ interface FormikAutosuggestProps<SuggestionType> {
   onBlur?: () => void;
 }
 
-export const FormikAutosuggest: FC<FormikAutosuggestProps<
-  Record<string, any>
->> = ({
+export const FormikAutosuggest = <SuggestionType extends Record<string, any>>({
   records,
   suggestions,
   setSuggestions,
@@ -30,8 +28,8 @@ export const FormikAutosuggest: FC<FormikAutosuggestProps<
   onSuggestionSelected,
   onChange,
   onBlur,
-}) => {
-  const getSuggestions = (inputValue: string): Record<string, any>[] => {
+}: FormikAutosuggestProps<SuggestionType>) => {
+  const getSuggestions = (inputValue: string): SuggestionType[] => {
     const trimmedInputValue = escapeRegexCharacters(
       inputValue.trim().toLowerCase(),
     );
@@ -45,7 +43,7 @@ export const FormikAutosuggest: FC<FormikAutosuggestProps<
 
   const onSuggestionsClearRequested = () => setSuggestions([]);
 
-  const renderSuggestion = (suggestion: Record<string, any>): ReactNode => (
+  const renderSuggestion = (suggestion: SuggestionType): ReactNode => (
     <div>{getSuggestionValue(suggestion)}</div>
   );
 
@@ -54,14 +52,14 @@ export const FormikAutosuggest: FC<FormikAutosuggestProps<
       suggestions={suggestions}
       onSuggestionsFetchRequested={onSuggestionsFetchRequested}
       onSuggestionsClearRequested={onSuggestionsClearRequested}
-      getSuggestionValue={(suggestion: Record<string, any>) =>
+      getSuggestionValue={(suggestion: SuggestionType) =>
         getSuggestionValue(suggestion)
       }
       renderSuggestion={renderSuggestion}
       shouldRenderSuggestions={() => true}
       onSuggestionSelected={(
         event: FormEvent<any>,
-        data: SuggestionSelectedEventData<Record<string, any>>,
+        data: SuggestionSelectedEventData<SuggestionType>,
       ) => {
         event.preventDefault();
         event.stopPropagation();

--- a/app/javascript/client/form/FormikAutosuggest.tsx
+++ b/app/javascript/client/form/FormikAutosuggest.tsx
@@ -1,0 +1,77 @@
+import React, { FC, FormEvent, ReactNode } from 'react';
+import Autosuggest, {
+  SuggestionsFetchRequestedParams,
+  SuggestionSelectedEventData,
+} from 'react-autosuggest';
+import { escapeRegexCharacters } from 'client/profiles/utils';
+
+interface FormikAutosuggestProps<SuggestionType> {
+  records: SuggestionType[];
+  suggestions: SuggestionType[];
+  setSuggestions: (suggestions: SuggestionType[]) => void;
+  getSuggestionValue: (suggestion: SuggestionType) => string;
+  suggestionValue: string;
+  onSuggestionSelected: (
+    event: FormEvent<any>,
+    data: SuggestionSelectedEventData<SuggestionType>,
+  ) => void;
+  onChange: (event: any) => void;
+  onBlur?: () => void;
+}
+
+export const FormikAutosuggest: FC<FormikAutosuggestProps<
+  Record<string, any>
+>> = ({
+  records,
+  suggestions,
+  setSuggestions,
+  getSuggestionValue,
+  suggestionValue,
+  onSuggestionSelected,
+  onChange,
+  onBlur,
+}) => {
+  const getSuggestions = (inputValue: string): Record<string, any>[] => {
+    const trimmedInputValue = escapeRegexCharacters(
+      inputValue.trim().toLowerCase(),
+    );
+    const regex = new RegExp('^' + trimmedInputValue, 'i');
+    return records.filter((record) => regex.test(getSuggestionValue(record)));
+  };
+
+  const onSuggestionsFetchRequested = ({
+    value,
+  }: SuggestionsFetchRequestedParams) => setSuggestions(getSuggestions(value));
+
+  const onSuggestionsClearRequested = () => setSuggestions([]);
+
+  const renderSuggestion = (suggestion: Record<string, any>): ReactNode => (
+    <div>{getSuggestionValue(suggestion)}</div>
+  );
+
+  return (
+    <Autosuggest
+      suggestions={suggestions}
+      onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+      onSuggestionsClearRequested={onSuggestionsClearRequested}
+      getSuggestionValue={(suggestion: Record<string, any>) =>
+        getSuggestionValue(suggestion)
+      }
+      renderSuggestion={renderSuggestion}
+      shouldRenderSuggestions={() => true}
+      onSuggestionSelected={(
+        event: FormEvent<any>,
+        data: SuggestionSelectedEventData<Record<string, any>>,
+      ) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onSuggestionSelected(event, data);
+      }}
+      inputProps={{
+        onChange,
+        value: suggestionValue,
+        onBlur: onBlur ? onBlur : () => null,
+      }}
+    />
+  );
+};

--- a/app/javascript/client/form/FormikAutosuggest.tsx
+++ b/app/javascript/client/form/FormikAutosuggest.tsx
@@ -8,9 +8,9 @@ import { escapeRegexCharacters } from 'client/profiles/utils';
 interface FormikAutosuggestProps<SuggestionType> {
   records: SuggestionType[];
   suggestions: SuggestionType[];
-  setSuggestions: (suggestions: SuggestionType[]) => void;
+  setSuggestions: (suggestions: any[]) => void;
   getSuggestionValue: (suggestion: SuggestionType) => string;
-  suggestionValue: string;
+  inputValue: string;
   onSuggestionSelected: (
     event: FormEvent<any>,
     data: SuggestionSelectedEventData<SuggestionType>,
@@ -26,7 +26,7 @@ export const FormikAutosuggest: FC<FormikAutosuggestProps<
   suggestions,
   setSuggestions,
   getSuggestionValue,
-  suggestionValue,
+  inputValue,
   onSuggestionSelected,
   onChange,
   onBlur,
@@ -69,7 +69,7 @@ export const FormikAutosuggest: FC<FormikAutosuggestProps<
       }}
       inputProps={{
         onChange,
-        value: suggestionValue,
+        value: inputValue,
         onBlur: onBlur ? onBlur : () => null,
       }}
     />

--- a/app/javascript/client/form/TextArea.tsx
+++ b/app/javascript/client/form/TextArea.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLProps, forwardRef, RefObject } from 'react';
-import { colors } from 'client/shared/styles';
+import { colors, text } from 'client/shared/styles';
 import styled from 'styled-components';
 
 interface TextAreaProps
@@ -9,9 +9,11 @@ const StyledTextArea = styled.textarea`
   width: 95%;
   border: 1px solid ${colors.lightGray};
   border-radius: 8px;
-  height: 100px;
+  height: 250px;
   padding-top: 1rem;
   padding-left: 1rem;
+  font-family: Quicksand;
+  font-size: ${text[2]};
 `;
 
 export const TextArea = forwardRef(({ ...rest }: TextAreaProps, ref) => (

--- a/app/javascript/client/form/TextArea.tsx
+++ b/app/javascript/client/form/TextArea.tsx
@@ -3,13 +3,16 @@ import { colors, text } from 'client/shared/styles';
 import styled from 'styled-components';
 
 interface TextAreaProps
-  extends Omit<HTMLProps<HTMLTextAreaElement>, 'as' | 'ref' | 'autoComplete'> {}
+  extends Omit<HTMLProps<HTMLTextAreaElement>, 'as' | 'ref' | 'autoComplete'> {
+  height?: string;
+}
 
 const StyledTextArea = styled.textarea`
   width: 95%;
   border: 1px solid ${colors.lightGray};
   border-radius: 8px;
-  height: 250px;
+  height: ${(props: Pick<TextAreaProps, 'height'>) =>
+    props.height ? props.height : '100px'};
   padding-top: 1rem;
   padding-left: 1rem;
   font-family: Quicksand;

--- a/app/javascript/client/graphqlTypes.tsx
+++ b/app/javascript/client/graphqlTypes.tsx
@@ -470,6 +470,7 @@ export type Place = {
 export type Query = {
   __typename?: 'Query';
   parentChildRelationshipByParentIdAndChildId?: Maybe<ParentChild>;
+  people?: Maybe<Array<Person>>;
   personById?: Maybe<Person>;
   siblingRelationshipBySiblingIds?: Maybe<SiblingRelationship>;
   user?: Maybe<User>;
@@ -1055,6 +1056,17 @@ export type UpdateParentChildRelationshipMutation = (
       & Pick<Error, 'path' | 'message'>
     )>> }
   ) }
+);
+
+export type GetUserPeopleQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetUserPeopleQuery = (
+  { __typename?: 'Query' }
+  & { people?: Maybe<Array<(
+    { __typename?: 'Person' }
+    & Pick<Person, 'id' | 'firstName' | 'lastName'>
+  )>> }
 );
 
 export type GetParentChildRelationshipQueryVariables = Exact<{
@@ -2210,6 +2222,40 @@ export function useUpdateParentChildRelationshipMutation(baseOptions?: Apollo.Mu
 export type UpdateParentChildRelationshipMutationHookResult = ReturnType<typeof useUpdateParentChildRelationshipMutation>;
 export type UpdateParentChildRelationshipMutationResult = Apollo.MutationResult<UpdateParentChildRelationshipMutation>;
 export type UpdateParentChildRelationshipMutationOptions = Apollo.BaseMutationOptions<UpdateParentChildRelationshipMutation, UpdateParentChildRelationshipMutationVariables>;
+export const GetUserPeopleDocument = gql`
+    query GetUserPeople {
+  people {
+    id
+    firstName
+    lastName
+  }
+}
+    `;
+
+/**
+ * __useGetUserPeopleQuery__
+ *
+ * To run a query within a React component, call `useGetUserPeopleQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetUserPeopleQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetUserPeopleQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetUserPeopleQuery(baseOptions?: Apollo.QueryHookOptions<GetUserPeopleQuery, GetUserPeopleQueryVariables>) {
+        return Apollo.useQuery<GetUserPeopleQuery, GetUserPeopleQueryVariables>(GetUserPeopleDocument, baseOptions);
+      }
+export function useGetUserPeopleLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetUserPeopleQuery, GetUserPeopleQueryVariables>) {
+          return Apollo.useLazyQuery<GetUserPeopleQuery, GetUserPeopleQueryVariables>(GetUserPeopleDocument, baseOptions);
+        }
+export type GetUserPeopleQueryHookResult = ReturnType<typeof useGetUserPeopleQuery>;
+export type GetUserPeopleLazyQueryHookResult = ReturnType<typeof useGetUserPeopleLazyQuery>;
+export type GetUserPeopleQueryResult = Apollo.QueryResult<GetUserPeopleQuery, GetUserPeopleQueryVariables>;
 export const GetParentChildRelationshipDocument = gql`
     query GetParentChildRelationship($input: ParentChildInput!) {
   parentChildRelationshipByParentIdAndChildId(input: $input) {

--- a/app/javascript/client/graphqlTypes.tsx
+++ b/app/javascript/client/graphqlTypes.tsx
@@ -1065,8 +1065,13 @@ export type GetUserPeopleQuery = (
   { __typename?: 'Query' }
   & { people?: Maybe<Array<(
     { __typename?: 'Person' }
-    & Pick<Person, 'id' | 'firstName' | 'lastName'>
+    & UserPersonInfoFragment
   )>> }
+);
+
+export type UserPersonInfoFragment = (
+  { __typename?: 'Person' }
+  & Pick<Person, 'id' | 'firstName' | 'lastName'>
 );
 
 export type GetParentChildRelationshipQueryVariables = Exact<{
@@ -1382,6 +1387,13 @@ export const PersonInfoFragmentDoc = gql`
 }
     ${SubContactInfoFragmentDoc}
 ${PersonPlaceInfoFragmentDoc}`;
+export const UserPersonInfoFragmentDoc = gql`
+    fragment UserPersonInfo on Person {
+  id
+  firstName
+  lastName
+}
+    `;
 export const GetUserDocument = gql`
     query GetUser {
   user {
@@ -2225,12 +2237,10 @@ export type UpdateParentChildRelationshipMutationOptions = Apollo.BaseMutationOp
 export const GetUserPeopleDocument = gql`
     query GetUserPeople {
   people {
-    id
-    firstName
-    lastName
+    ...UserPersonInfo
   }
 }
-    `;
+    ${UserPersonInfoFragmentDoc}`;
 
 /**
  * __useGetUserPeopleQuery__

--- a/app/javascript/client/home/HomeContainer.tsx
+++ b/app/javascript/client/home/HomeContainer.tsx
@@ -101,17 +101,23 @@ const ProfileLinkContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-bottom: ${spacing[1]};
+  flex-wrap: wrap;
 `;
 
 const ProfileLink = styled(StyledLink)`
   min-width: fit-content;
+  margin-bottom: ${spacing[1]};
+`;
+
+const AgeContainer = styled.div`
+  margin-bottom: ${spacing[1]};
 `;
 
 const StyledSwatch = styled(Swatch)`
   padding: 3px 9px;
   margin-left: 10px;
   margin-right: 0;
+  margin-bottom: ${spacing[1]};
 `;
 
 const SelectedTagContainer = styled.div`
@@ -192,7 +198,9 @@ const InternalHomeContainer: FC<HomeContainerProps> = () => {
             {person.firstName}
             {person.lastName && ` ${person.lastName}`}
           </ProfileLink>
-          {getAgeContent(person.age, person.monthsOld)}
+          <AgeContainer>
+            {getAgeContent(person.age, person.monthsOld)}
+          </AgeContainer>
           {tagItems}
         </ProfileLinkContainer>
       );

--- a/app/javascript/client/profiles/PersonContainer.tsx
+++ b/app/javascript/client/profiles/PersonContainer.tsx
@@ -274,7 +274,11 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
         <Modal onClose={() => setEditNameFlag(false)}>
           <PersonForm
             setEditFlag={setEditNameFlag}
-            initialValues={{ firstName, middleName, lastName }}
+            initialValues={{
+              firstName,
+              middleName: middleName ? middleName : '',
+              lastName: lastName ? lastName : '',
+            }}
             personId={personId}
           />
         </Modal>
@@ -339,6 +343,7 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
             setFieldToAdd={setFieldToAdd}
             parentId={personId}
             personFirstName={firstName}
+            relations={relations}
           />
         </Modal>
       )}
@@ -408,6 +413,7 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
           actualChildren={children}
           parentId={personId}
           parentLastName={lastName}
+          relations={relations}
         />
       )}
       {siblings && siblings.length > 0 && (

--- a/app/javascript/client/profiles/PersonContainer.tsx
+++ b/app/javascript/client/profiles/PersonContainer.tsx
@@ -210,7 +210,6 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
   });
 
   if (!personData) return null;
-  // if (!personData.personById) return null;
   if (!personData.personById) {
     history.push('/home');
     return null;

--- a/app/javascript/client/profiles/PersonContainer.tsx
+++ b/app/javascript/client/profiles/PersonContainer.tsx
@@ -232,6 +232,10 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
     personPlaces,
   } = personData.personById;
 
+  const relations = (parents ? parents : [])
+    .concat(children ? children : [])
+    .concat(siblings ? siblings : []);
+
   const hasAge = age || monthsOld;
   const hasBirthdate = birthYear || birthMonth;
   const hasVitals = gender || hasAge || hasBirthdate;
@@ -325,6 +329,7 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
             setFieldToAdd={setFieldToAdd}
             childId={personId}
             personFirstName={firstName}
+            relations={relations}
           />
         </Modal>
       )}
@@ -395,6 +400,7 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
           parents={parents}
           childId={personId}
           childLastName={lastName}
+          relations={relations}
         />
       )}
       {children && children.length > 0 && (

--- a/app/javascript/client/profiles/PersonContainer.tsx
+++ b/app/javascript/client/profiles/PersonContainer.tsx
@@ -353,6 +353,7 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
             setFieldToAdd={setFieldToAdd}
             siblingOneId={personId}
             personFirstName={firstName}
+            relations={relations}
           />
         </Modal>
       )}
@@ -421,6 +422,7 @@ const InternalPersonContainer: FC<PersonContainerProps> = ({ history }) => {
           siblings={siblings}
           otherSiblingId={personId}
           otherSiblingLastName={lastName}
+          relations={relations}
         />
       )}
       {hasPersonalHistory && (

--- a/app/javascript/client/profiles/notes/NoteForm.tsx
+++ b/app/javascript/client/profiles/notes/NoteForm.tsx
@@ -121,7 +121,7 @@ export const NoteForm: FC<NoteFormProps> = ({
       >
         {({ isSubmitting }) => (
           <Form>
-            <Field name="content" component={FormikTextArea} />
+            <Field name="content" component={FormikTextArea} height="250px" />
             <Button marginRight="1rem" type="submit" disabled={isSubmitting}>
               Save
             </Button>

--- a/app/javascript/client/profiles/parent_child/ChildForm.tsx
+++ b/app/javascript/client/profiles/parent_child/ChildForm.tsx
@@ -4,7 +4,6 @@ import {
   useCreateAgeMutation,
   useCreateParentChildRelationshipMutation,
   useUpdateParentChildRelationshipMutation,
-  useGetUserForHomeContainerQuery,
   useGetUserPeopleQuery,
   SubContactInfoFragment,
 } from 'client/graphqlTypes';
@@ -21,11 +20,11 @@ import { Button } from 'client/common/Button';
 import { GlobalError } from 'client/common/GlobalError';
 import { Text } from 'client/common/Text';
 import { SectionDivider } from 'client/profiles/PersonContainer';
-import { CHILD_TYPE_OPTIONS, getFullNameFromPerson } from './utils';
+import { CHILD_TYPE_OPTIONS } from './utils';
 import {
   NEW_OR_CURRENT_CONTACT_OPTIONS,
   filterOutRelationsFromAndSortPeople,
-  buildPeopleOptions,
+  getFullNameFromPerson,
 } from 'client/profiles/utils';
 import * as yup from 'yup';
 import { handleFormErrors } from 'client/utils/formik';
@@ -118,10 +117,6 @@ export const ChildForm: FC<ChildFormProps> = ({
     : [];
   const [peopleSuggestions, setPeopleSuggestions] = useState(filteredPeople);
   const [childInputValue, setChildInputValue] = useState('');
-
-  // const { data: userData } = useGetUserForHomeContainerQuery();
-  // const people = userData?.user?.people ? userData?.user?.people : [];
-  // const peopleOptions = buildPeopleOptions(people, parentId);
 
   const cancel = () => {
     if (setFieldToAdd) {
@@ -334,15 +329,6 @@ export const ChildForm: FC<ChildFormProps> = ({
                     )}
                   </Field>
                 )}
-              {/* {values.newOrCurrentContact === 'current_person' &&
-                setFieldToAdd && (
-                  <Field
-                    name="formChildId"
-                    label="Child"
-                    component={FormikSelectInput}
-                    options={peopleOptions}
-                  />
-                )} */}
               <Field
                 name="parentType"
                 label="Type of child (optional)"

--- a/app/javascript/client/profiles/parent_child/ChildItem.tsx
+++ b/app/javascript/client/profiles/parent_child/ChildItem.tsx
@@ -20,12 +20,14 @@ interface ChildItemProps {
   child: SubContactInfoFragment;
   parentId: string;
   parentLastName?: string | null | undefined;
+  relations: SubContactInfoFragment[];
 }
 
 export const ChildItem: FC<ChildItemProps> = ({
   child,
   parentId,
   parentLastName,
+  relations,
 }) => {
   const { id, firstName, lastName, age, monthsOld, gender } = child;
   const { data: parentChildData } = useGetParentChildRelationshipQuery({
@@ -107,6 +109,7 @@ export const ChildItem: FC<ChildItemProps> = ({
             parentId={parentId}
             personFirstName=""
             setModalOpen={setModalOpen}
+            relations={relations}
           />
         </Modal>
       )}

--- a/app/javascript/client/profiles/parent_child/ChildrenContainer.tsx
+++ b/app/javascript/client/profiles/parent_child/ChildrenContainer.tsx
@@ -11,12 +11,14 @@ interface ChildrenContainerProps {
   actualChildren: SubContactInfoFragment[];
   parentLastName?: string | null | undefined;
   parentId: string;
+  relations: SubContactInfoFragment[];
 }
 
 export const ChildrenContainer: FC<ChildrenContainerProps> = ({
   actualChildren,
   parentLastName,
   parentId,
+  relations,
 }) => {
   const childItems = actualChildren.map((child) => {
     return (
@@ -25,6 +27,7 @@ export const ChildrenContainer: FC<ChildrenContainerProps> = ({
         child={child}
         parentId={parentId}
         parentLastName={parentLastName ? parentLastName : ''}
+        relations={relations}
       />
     );
   });

--- a/app/javascript/client/profiles/parent_child/ParentForm.spec.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentForm.spec.tsx
@@ -13,7 +13,7 @@ import { getUserPeopleQuery } from 'client/test/queries/getUserPeople';
 import { createAgeMutation } from 'client/test/mutations/createAge';
 import { createPersonMutation } from 'client/test/mutations/addPerson';
 import { ReactWrapper, mount } from 'enzyme';
-import { Form, Field } from 'formik';
+import { Form } from 'formik';
 import { act } from 'react-dom/test-utils';
 import wait from 'waait';
 import * as formikHelpers from 'client/utils/formik';

--- a/app/javascript/client/profiles/parent_child/ParentForm.spec.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentForm.spec.tsx
@@ -9,16 +9,16 @@ import { FormUtils, formUtils } from 'client/test/utils/formik';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { createParentChildRelationshipMutation } from 'client/test/mutations/createParentChild';
-import { getUserForHomeContainerQuery } from 'client/test/queries/getUserForHomeContainer';
+import { getUserPeopleQuery } from 'client/test/queries/getUserPeople';
 import { createAgeMutation } from 'client/test/mutations/createAge';
 import { createPersonMutation } from 'client/test/mutations/addPerson';
 import { ReactWrapper, mount } from 'enzyme';
-import { Form } from 'formik';
+import { Form, Field } from 'formik';
 import { act } from 'react-dom/test-utils';
 import wait from 'waait';
 import * as formikHelpers from 'client/utils/formik';
 
-describe('<ParentChildForm />', () => {
+describe('<ParentForm />', () => {
   let mountComponent: (
     mocks?: MockedResponse[],
     props?: ParentFormProps,
@@ -39,7 +39,7 @@ describe('<ParentChildForm />', () => {
     };
     defaultMocks = [
       createParentChildRelationshipMutation(),
-      getUserForHomeContainerQuery(),
+      getUserPeopleQuery(),
       createAgeMutation(),
       createPersonMutation(),
     ];
@@ -98,7 +98,7 @@ describe('<ParentChildForm />', () => {
     form = formUtils<ParentFormData>(component.find(Form));
 
     expect(form.findInputByName('newOrCurrentContact').exists()).toBe(true);
-    expect(form.findInputByName('formParentId', 'select').exists()).toBe(true);
+    expect(component.find("Field[name='formParentId']").exists()).toBe(true);
     expect(form.findInputByName('parentType', 'select').exists()).toBe(true);
     expect(form.findInputByName('note', 'textarea').exists()).toBe(true);
   });
@@ -155,7 +155,7 @@ describe('<ParentChildForm />', () => {
         );
 
         await mountComponent(
-          [createParentChildRelationship, getUserForHomeContainerQuery()],
+          [createParentChildRelationship, getUserPeopleQuery()],
           currentPersonProps,
         );
         form = formUtils<ParentFormData>(component.find(Form));
@@ -183,7 +183,7 @@ describe('<ParentChildForm />', () => {
         const createParentChildRelationship = createParentChildRelationshipMutation();
 
         await mountComponent(
-          [createParentChildRelationship, getUserForHomeContainerQuery()],
+          [createParentChildRelationship, getUserPeopleQuery()],
           props,
         );
         form = formUtils<ParentFormData>(component.find(Form));
@@ -258,12 +258,7 @@ describe('<ParentChildForm />', () => {
         );
 
         await mountComponent(
-          [
-            createPerson,
-            createAge,
-            createParentChild,
-            getUserForHomeContainerQuery(),
-          ],
+          [createPerson, createAge, createParentChild, getUserPeopleQuery()],
           defaultProps,
         );
         form = formUtils<ParentFormData>(component.find(Form));

--- a/app/javascript/client/profiles/parent_child/ParentForm.spec.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentForm.spec.tsx
@@ -35,6 +35,7 @@ describe('<ParentChildForm />', () => {
       personFirstName: 'Ada',
       setFieldToAdd: jest.fn(),
       childId: 'ada-lovelace-uuid',
+      relations: [],
     };
     defaultMocks = [
       createParentChildRelationshipMutation(),

--- a/app/javascript/client/profiles/parent_child/ParentForm.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentForm.tsx
@@ -21,10 +21,11 @@ import { Button } from 'client/common/Button';
 import { GlobalError } from 'client/common/GlobalError';
 import { Text } from 'client/common/Text';
 import { SectionDivider } from 'client/profiles/PersonContainer';
-import { PARENT_TYPE_OPTIONS, getFullNameFromPerson } from './utils';
+import { PARENT_TYPE_OPTIONS } from './utils';
 import {
   NEW_OR_CURRENT_CONTACT_OPTIONS,
   filterOutRelationsFromAndSortPeople,
+  getFullNameFromPerson,
 } from 'client/profiles/utils';
 import * as yup from 'yup';
 import { gql } from '@apollo/client';

--- a/app/javascript/client/profiles/parent_child/ParentForm.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentForm.tsx
@@ -199,6 +199,7 @@ export const ParentForm: FC<ParentFormProps> = ({
     : [];
   const [peopleSuggestions, setPeopleSuggestions] = useState(filteredPeople);
   const [parentInputValue, setParentInputValue] = useState('');
+  // const FormikAutosuggest = withAutosuggest(filteredPeople[0]);
 
   const cancel = () => {
     if (setFieldToAdd) {
@@ -392,7 +393,7 @@ export const ParentForm: FC<ParentFormProps> = ({
                 setFieldToAdd && (
                   <Field name="formParentId">
                     {({ form }: FieldProps) => (
-                      <FormikAutosuggest
+                      <FormikAutosuggest<SubContactInfoFragment>
                         records={filteredPeople}
                         suggestions={peopleSuggestions}
                         setSuggestions={setPeopleSuggestions}

--- a/app/javascript/client/profiles/parent_child/ParentForm.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentForm.tsx
@@ -4,7 +4,6 @@ import {
   useCreateAgeMutation,
   useCreateParentChildRelationshipMutation,
   useUpdateParentChildRelationshipMutation,
-  useGetUserForHomeContainerQuery,
   useGetUserPeopleQuery,
   SubContactInfoFragment,
 } from 'client/graphqlTypes';
@@ -22,10 +21,7 @@ import { GlobalError } from 'client/common/GlobalError';
 import { Text } from 'client/common/Text';
 import { SectionDivider } from 'client/profiles/PersonContainer';
 import { PARENT_TYPE_OPTIONS, getFullNameFromPerson } from './utils';
-import {
-  NEW_OR_CURRENT_CONTACT_OPTIONS,
-  buildPeopleOptions,
-} from 'client/profiles/utils';
+import { NEW_OR_CURRENT_CONTACT_OPTIONS } from 'client/profiles/utils';
 import * as yup from 'yup';
 import { gql } from '@apollo/client';
 import { handleFormErrors } from 'client/utils/formik';
@@ -185,9 +181,7 @@ export const ParentForm: FC<ParentFormProps> = ({
   const [
     updateParentChildRelationship,
   ] = useUpdateParentChildRelationshipMutation();
-  // const { data: userData } = useGetUserForHomeContainerQuery();
   const { data: userPeople } = useGetUserPeopleQuery();
-  const people = userPeople?.people ? userPeople?.people : [];
   const personRelationIds = new Set(relations.map((person) => person.id));
   personRelationIds.add(childId);
   const filteredPeople = userPeople?.people
@@ -456,15 +450,6 @@ export const ParentForm: FC<ParentFormProps> = ({
                     )}
                   </Field>
                 )}
-              {/* {values.newOrCurrentContact === 'current_person' &&
-                setFieldToAdd && (
-                  <Field
-                    name="formParentId"
-                    label="Parent"
-                    component={FormikSelectInput}
-                    options={peopleOptions}
-                  />
-                )} */}
               <Field
                 name="parentType"
                 label="Type of parent (optional)"

--- a/app/javascript/client/profiles/parent_child/ParentItem.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentItem.tsx
@@ -52,12 +52,14 @@ interface ParentItemProps {
   parent: SubContactInfoFragment;
   childLastName?: string | null | undefined;
   childId: string;
+  relations: SubContactInfoFragment[];
 }
 
 export const ParentItem: FC<ParentItemProps> = ({
   parent,
   childId,
   childLastName,
+  relations,
 }) => {
   const { id, firstName, lastName, age, gender } = parent;
   const { data: parentChildData } = useGetParentChildRelationshipQuery({
@@ -140,6 +142,7 @@ export const ParentItem: FC<ParentItemProps> = ({
             childId={childId}
             personFirstName=""
             setModalOpen={setModalOpen}
+            relations={relations}
           />
         </Modal>
       )}

--- a/app/javascript/client/profiles/parent_child/ParentsContainer.tsx
+++ b/app/javascript/client/profiles/parent_child/ParentsContainer.tsx
@@ -11,12 +11,14 @@ interface ParentsContainerProps {
   parents: SubContactInfoFragment[];
   childLastName?: string | null | undefined;
   childId: string;
+  relations: SubContactInfoFragment[];
 }
 
 export const ParentsContainer: FC<ParentsContainerProps> = ({
   parents,
   childId,
   childLastName,
+  relations,
 }) => {
   const parentItems = parents.map((parent) => {
     return (
@@ -25,6 +27,7 @@ export const ParentsContainer: FC<ParentsContainerProps> = ({
         parent={parent}
         childId={childId}
         childLastName={childLastName ? childLastName : ''}
+        relations={relations}
       />
     );
   });

--- a/app/javascript/client/profiles/parent_child/utils.tsx
+++ b/app/javascript/client/profiles/parent_child/utils.tsx
@@ -97,5 +97,7 @@ export const parentTypeColors: Record<
   },
 };
 
-export const getFullNameFromPerson = (person: Record<string, any>): string =>
+export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;
+// export const getFullNameFromPerson = (person: Record<string, any>): string =>
+//   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/profiles/parent_child/utils.tsx
+++ b/app/javascript/client/profiles/parent_child/utils.tsx
@@ -97,5 +97,7 @@ export const parentTypeColors: Record<
   },
 };
 
-export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
+export const getFullNameFromPerson = (person: Record<string, any>): string =>
   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;
+// export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
+//   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/profiles/parent_child/utils.tsx
+++ b/app/javascript/client/profiles/parent_child/utils.tsx
@@ -1,4 +1,5 @@
 import { colors } from 'client/shared/styles';
+import { SubContactInfoFragment } from 'client/graphqlTypes';
 
 export const PARENT_TYPE_OPTIONS = [
   { label: '', value: '' },
@@ -95,3 +96,6 @@ export const parentTypeColors: Record<
     textColor: 'lightPink',
   },
 };
+
+export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
+  person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/profiles/parent_child/utils.tsx
+++ b/app/javascript/client/profiles/parent_child/utils.tsx
@@ -99,5 +99,3 @@ export const parentTypeColors: Record<
 
 export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;
-// export const getFullNameFromPerson = (person: Record<string, any>): string =>
-//   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/profiles/parent_child/utils.tsx
+++ b/app/javascript/client/profiles/parent_child/utils.tsx
@@ -1,5 +1,4 @@
 import { colors } from 'client/shared/styles';
-import { SubContactInfoFragment } from 'client/graphqlTypes';
 
 export const PARENT_TYPE_OPTIONS = [
   { label: '', value: '' },
@@ -96,6 +95,3 @@ export const parentTypeColors: Record<
     textColor: 'lightPink',
   },
 };
-
-export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
-  person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/profiles/parent_child/utils.tsx
+++ b/app/javascript/client/profiles/parent_child/utils.tsx
@@ -99,5 +99,3 @@ export const parentTypeColors: Record<
 
 export const getFullNameFromPerson = (person: Record<string, any>): string =>
   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;
-// export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
-//   person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/profiles/sibling/SiblingForm.spec.tsx
+++ b/app/javascript/client/profiles/sibling/SiblingForm.spec.tsx
@@ -9,7 +9,7 @@ import { FormUtils, formUtils } from 'client/test/utils/formik';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { createSiblingRelationshipMutation } from 'client/test/mutations/createSibling';
-import { getUserForHomeContainerQuery } from 'client/test/queries/getUserForHomeContainer';
+import { getUserPeopleQuery } from 'client/test/queries/getUserPeople';
 import { ReactWrapper, mount } from 'enzyme';
 import { Form } from 'formik';
 import { act } from 'react-dom/test-utils';
@@ -32,11 +32,9 @@ describe('<SiblingForm />', () => {
       personFirstName: 'Andre',
       setFieldToAdd: jest.fn(),
       siblingOneId: 'andre-weil-uuid',
+      relations: [],
     };
-    defaultMocks = [
-      createSiblingRelationshipMutation(),
-      getUserForHomeContainerQuery(),
-    ];
+    defaultMocks = [createSiblingRelationshipMutation(), getUserPeopleQuery()];
     currentPersonProps = {
       ...defaultProps,
       initialValues: {
@@ -92,7 +90,7 @@ describe('<SiblingForm />', () => {
     form = formUtils<SiblingFormData>(component.find(Form));
 
     expect(form.findInputByName('newOrCurrentContact').exists()).toBe(true);
-    expect(form.findInputByName('formSiblingId', 'select').exists()).toBe(true);
+    expect(component.find("Field[name='formSiblingId']").exists()).toBe(true);
     expect(form.findInputByName('siblingType', 'select').exists()).toBe(true);
     expect(form.findInputByName('note', 'textarea').exists()).toBe(true);
   });
@@ -103,7 +101,7 @@ describe('<SiblingForm />', () => {
         const createSiblingRelationship = createSiblingRelationshipMutation();
 
         await mountComponent(
-          [createSiblingRelationship, getUserForHomeContainerQuery()],
+          [createSiblingRelationship, getUserPeopleQuery()],
           defaultProps,
         );
         form = formUtils<SiblingFormData>(component.find(Form));
@@ -159,28 +157,21 @@ describe('<SiblingForm />', () => {
           },
         };
         const userDataMock = {
-          user: {
-            id: 'andre-weil-uuid',
-            email: 'andre@weil.com',
-            people: [
-              {
-                id: 'alexander-grothendieck-uuid',
-                firstName: 'Alexander',
-                lastName: 'Grothendieck',
-                showOnDashboard: false,
-              },
-            ],
-          },
+          people: [
+            {
+              id: 'alexander-grothendieck-uuid',
+              firstName: 'Alexander',
+              lastName: 'Grothendieck',
+              showOnDashboard: false,
+            },
+          ],
         };
         const createSiblingRelationship = createSiblingRelationshipMutation(
           currentPersonMock,
         );
 
         await mountComponent(
-          [
-            createSiblingRelationship,
-            getUserForHomeContainerQuery(userDataMock),
-          ],
+          [createSiblingRelationship, getUserPeopleQuery(userDataMock)],
           currentPersonProps,
         );
         form = formUtils<SiblingFormData>(component.find(Form));

--- a/app/javascript/client/profiles/sibling/SiblingItem.tsx
+++ b/app/javascript/client/profiles/sibling/SiblingItem.tsx
@@ -39,12 +39,14 @@ interface SiblingItemProps {
   sibling: SubContactInfoFragment;
   otherSiblingLastName?: string | null | undefined;
   otherSiblingId: string;
+  relations: SubContactInfoFragment[];
 }
 
 export const SiblingItem: FC<SiblingItemProps> = ({
   sibling,
   otherSiblingId,
   otherSiblingLastName,
+  relations,
 }) => {
   const { id, firstName, lastName, age, gender } = sibling;
   const { data: siblingRelationshipData } = useGetSiblingRelationshipQuery({
@@ -126,6 +128,7 @@ export const SiblingItem: FC<SiblingItemProps> = ({
             setEditFlag={setEditFlag}
             siblingOneId={otherSiblingId}
             setModalOpen={setModalOpen}
+            relations={relations}
           />
         </Modal>
       )}

--- a/app/javascript/client/profiles/sibling/SiblingsContainer.tsx
+++ b/app/javascript/client/profiles/sibling/SiblingsContainer.tsx
@@ -11,12 +11,14 @@ interface SiblingsContainerProps {
   siblings: SubContactInfoFragment[];
   otherSiblingLastName?: string | null | undefined;
   otherSiblingId: string;
+  relations: SubContactInfoFragment[];
 }
 
 export const SiblingsContainer: FC<SiblingsContainerProps> = ({
   siblings,
   otherSiblingId,
   otherSiblingLastName,
+  relations,
 }) => {
   const siblingItems = siblings.map((sibling) => {
     return (
@@ -25,6 +27,7 @@ export const SiblingsContainer: FC<SiblingsContainerProps> = ({
         sibling={sibling}
         otherSiblingId={otherSiblingId}
         otherSiblingLastName={otherSiblingLastName}
+        relations={relations}
       />
     );
   });

--- a/app/javascript/client/profiles/tags/PersonTagForm.tsx
+++ b/app/javascript/client/profiles/tags/PersonTagForm.tsx
@@ -117,7 +117,7 @@ interface SwatchProps extends Omit<HTMLProps<HTMLDivElement>, 'as' | 'ref'> {
 }
 
 export const Swatch = styled.div`
-  height: 20px;
+  height: fit-content;
   padding: 0.5rem 1rem;
   background-color: ${({ swatchColor }: SwatchProps) =>
     swatchColor ? swatchColor : `${colors.white}`};
@@ -134,6 +134,7 @@ export const Swatch = styled.div`
   margin-right: 10px;
   margin-bottom: ${({ marginBottom }: SwatchProps) =>
     marginBottom ? marginBottom : '0'};
+  text-align: center;
 `;
 
 const PersonTagFormValidationSchema = yup.object().shape({

--- a/app/javascript/client/profiles/tags/PersonTagForm.tsx
+++ b/app/javascript/client/profiles/tags/PersonTagForm.tsx
@@ -169,7 +169,19 @@ export const PersonTagForm: FC<PersonTagFormProps> = ({
     variables: { userId: userId ? userId : '' },
   });
   const tags =
-    tagsData && tagsData.userTagsByUserId ? tagsData.userTagsByUserId : [];
+    tagsData && tagsData.userTagsByUserId
+      ? tagsData.userTagsByUserId.slice().sort((t1, t2) => {
+          const tagName1 = t1.name.toUpperCase();
+          const tagName2 = t2.name.toUpperCase();
+          if (tagName1 < tagName2) {
+            return -1;
+          } else if (tagName1 > tagName2) {
+            return 1;
+          } else {
+            return 0;
+          }
+        })
+      : [];
   const colorPickerRef = useRef(null);
   const formikRef: React.RefObject<any> = useRef();
   const [filteredSuggestions, setFilteredSuggestions] = useState(tags);

--- a/app/javascript/client/profiles/tags/PersonTagForm.tsx
+++ b/app/javascript/client/profiles/tags/PersonTagForm.tsx
@@ -165,7 +165,7 @@ export const PersonTagForm: FC<PersonTagFormProps> = ({
 }) => {
   const { userId } = useContext(AuthContext);
   const [createPersonTagMutation] = useCreatePersonTagMutation();
-  const { data: tagsData } = useGetUserTagsQuery({
+  const { data: tagsData, refetch: refetchTagsData } = useGetUserTagsQuery({
     variables: { userId: userId ? userId : '' },
   });
   const tags =
@@ -199,6 +199,7 @@ export const PersonTagForm: FC<PersonTagFormProps> = ({
 
   useEffect(() => {
     setColorPickerActive(false);
+    refetchTagsData();
   }, []);
 
   const cancel = () => {

--- a/app/javascript/client/profiles/tags/PersonTagForm.tsx
+++ b/app/javascript/client/profiles/tags/PersonTagForm.tsx
@@ -91,6 +91,7 @@ const ColorPickerOuterContainer = styled.div`
   margin-bottom: 50px;
   display: flex;
   width: 100%;
+  align-items: center;
 `;
 
 const ColorPickerInnerContainer = styled.div`
@@ -103,6 +104,10 @@ const ColorPickerInnerContainer = styled.div`
   box-shadow: 0 1px 8px rgba(0, 0, 0, 0.3);
   background: ${colors.white};
   z-index: 2;
+`;
+
+const OptionalTag = styled.div`
+  margin-right: 2rem;
 `;
 
 interface SwatchProps extends Omit<HTMLProps<HTMLDivElement>, 'as' | 'ref'> {
@@ -305,10 +310,11 @@ export const PersonTagForm: FC<PersonTagFormProps> = ({
                 onClick={handleChooseColorClick}
                 buttonActive={colorPickerActive}
                 type="button"
-                marginRight="2rem"
+                marginRight="0.75rem"
               >
                 Choose color
               </ColorPickerButton>
+              <OptionalTag>(optional)</OptionalTag>
               {colorPickerActive && (
                 <ColorPickerInnerContainer ref={colorPickerRef}>
                   <Field name="color">

--- a/app/javascript/client/profiles/tags/TagItem.tsx
+++ b/app/javascript/client/profiles/tags/TagItem.tsx
@@ -40,7 +40,7 @@ export const TagItem: FC<TagProps> = ({ tag, personId }) => {
   return modalOpen ? (
     <Modal onClose={() => setModalOpen(false)}>
       <Text marginBottom={3} fontSize={3} bold>
-        Are you sure you want to delete this field?
+        Are you sure you want to remove this tag from the profile?
       </Text>
       <Button marginRight="1rem" onClick={() => deletePersonTag()}>
         Yes

--- a/app/javascript/client/profiles/utils.tsx
+++ b/app/javascript/client/profiles/utils.tsx
@@ -1,6 +1,9 @@
 import React, { ReactNode } from 'react';
 import { Option } from 'client/form/SelectInput';
-import { HomeContainerPersonInfoFragment } from 'client/graphqlTypes';
+import {
+  HomeContainerPersonInfoFragment,
+  UserPersonInfoFragment,
+} from 'client/graphqlTypes';
 import { AgeContainer } from 'client/profiles/parent_child/ParentItem';
 
 export const NEW_OR_CURRENT_CONTACT_OPTIONS = [
@@ -44,4 +47,24 @@ export const getAgeContent = (
     return <AgeContainer>{`(${age})`}</AgeContainer>;
   }
   return '';
+};
+
+export const filterOutRelationsFromAndSortPeople = (
+  people: UserPersonInfoFragment[],
+  relationIds: Set<string>,
+): UserPersonInfoFragment[] => {
+  return people
+    .filter((person) => !relationIds.has(person.id))
+    .slice()
+    .sort((p1, p2) => {
+      const personName1 = p1.firstName.toUpperCase();
+      const personName2 = p2.firstName.toUpperCase();
+      if (personName1 < personName2) {
+        return -1;
+      } else if (personName2 > personName1) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
 };

--- a/app/javascript/client/profiles/utils.tsx
+++ b/app/javascript/client/profiles/utils.tsx
@@ -3,6 +3,7 @@ import { Option } from 'client/form/SelectInput';
 import {
   HomeContainerPersonInfoFragment,
   UserPersonInfoFragment,
+  SubContactInfoFragment,
 } from 'client/graphqlTypes';
 import { AgeContainer } from 'client/profiles/parent_child/ParentItem';
 
@@ -68,3 +69,6 @@ export const filterOutRelationsFromAndSortPeople = (
       }
     });
 };
+
+export const getFullNameFromPerson = (person: SubContactInfoFragment): string =>
+  person.lastName ? person.firstName + ' ' + person.lastName : person.firstName;

--- a/app/javascript/client/test/queries/getUserPeople.ts
+++ b/app/javascript/client/test/queries/getUserPeople.ts
@@ -1,0 +1,23 @@
+import { GetUserPeopleDocument, GetUserPeopleQuery } from 'client/graphqlTypes';
+import { MockedResponse } from '@apollo/client/testing';
+
+export const getUserPeopleData: GetUserPeopleQuery = {
+  people: [
+    {
+      id: 'lord-byron-uuid',
+      firstName: 'Lord',
+      lastName: 'Byron',
+    },
+  ],
+};
+
+export const getUserPeopleQuery = (
+  data = getUserPeopleData,
+): MockedResponse => ({
+  request: {
+    query: GetUserPeopleDocument,
+  },
+  result: {
+    data,
+  },
+});

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,7 +19,7 @@
 #
 class Tag < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-  validates :color, format: { with: /\A#([0-9A-Fa-f]{3}){1,2}\z/, message: "Invalid hex color!" }
+  validates :color, format: { with: /\A#([0-9A-Fa-f]{3}){1,2}\z/, message: "Invalid hex color!" }, allow_nil: true
 
   has_many :person_tags, dependent: :destroy
   has_many :people, through: :person_tags


### PR DESCRIPTION
* Creates a common `FormikAutosuggest` component for using the `react-autosuggest` library
* Filters out already existent `parents`, `children` and `siblings` (`relations`), and the person themself, from a person's list of people when choosing an already existent contact as a `parent`, `child` or `sibling`
* Sorts the `tag` names alphabetically in the `Autosuggest`, and makes it so newly created ones appear without a refresh in the `Autosuggest`
* Fixes a bug that made it impossible to create a tag without a color